### PR TITLE
视频后台继续播放问题

### DIFF
--- a/SuperPlayer/SuperPlayerView.m
+++ b/SuperPlayer/SuperPlayerView.m
@@ -230,6 +230,8 @@ static UISlider * _volumeSlider;
  */
 - (void)resetPlayer {
     LOG_ME;
+    // 移除通知
+    [[NSNotificationCenter defaultCenter] removeObserver:self];
     // 暂停
     [self pause];
     

--- a/SuperPlayer/SuperPlayerView.m
+++ b/SuperPlayer/SuperPlayerView.m
@@ -230,8 +230,6 @@ static UISlider * _volumeSlider;
  */
 - (void)resetPlayer {
     LOG_ME;
-    // 移除通知
-    [[NSNotificationCenter defaultCenter] removeObserver:self];
     // 暂停
     [self pause];
     


### PR DESCRIPTION
调用resetPlayer移除通知后，再次playWithModel播放视频无法监听进入应用前后台通知，导致视频在后台继续播放。